### PR TITLE
feat: add 46elks handler;

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -48,6 +48,7 @@
     "@novu/expo": "^0.12.0",
     "@novu/fcm": "^0.12.0",
     "@novu/firetext": "^0.12.0",
+    "@novu/forty-six-elks": "^0.12.0",
     "@novu/gupshup": "^0.12.0",
     "@novu/infobip": "^0.12.0",
     "@novu/mailersend": "^0.12.0",

--- a/apps/api/src/app/events/services/sms-service/handlers/forty-six-elks.handler.ts
+++ b/apps/api/src/app/events/services/sms-service/handlers/forty-six-elks.handler.ts
@@ -1,0 +1,17 @@
+import { ChannelTypeEnum } from '@novu/shared';
+import { ICredentials } from '@novu/dal';
+import { BaseSmsHandler } from './base.handler';
+import { FortySixElksSmsProvider } from '@novu/forty-six-elks';
+
+export class FortySixElksHandler extends BaseSmsHandler {
+  constructor() {
+    super('forty-six-elks', ChannelTypeEnum.SMS);
+  }
+  buildProvider(credentials: ICredentials) {
+    this.provider = new FortySixElksSmsProvider({
+      user: credentials.user,
+      password: credentials.password,
+      from: credentials.from,
+    });
+  }
+}

--- a/apps/api/src/app/events/services/sms-service/handlers/index.ts
+++ b/apps/api/src/app/events/services/sms-service/handlers/index.ts
@@ -9,3 +9,4 @@ export * from './gupshup.handler';
 export * from './firetext.handler';
 export * from './infobip.handler';
 export * from './burst-sms.handler';
+export * from './forty-six-elks.handler';

--- a/apps/api/src/app/events/services/sms-service/sms.factory.ts
+++ b/apps/api/src/app/events/services/sms-service/sms.factory.ts
@@ -12,6 +12,7 @@ import {
   InfobipSmsHandler,
   BurstSmsHandler,
   ClickatellHandler,
+  FortySixElksHandler,
 } from './handlers';
 
 export class SmsFactory implements ISmsFactory {
@@ -27,6 +28,7 @@ export class SmsFactory implements ISmsFactory {
     new FiretextSmsHandler(),
     new InfobipSmsHandler(),
     new BurstSmsHandler(),
+    new FortySixElksHandler(),
   ];
 
   getHandler(integration: IntegrationEntity) {

--- a/libs/shared/src/consts/providers/channels/sms.ts
+++ b/libs/shared/src/consts/providers/channels/sms.ts
@@ -11,6 +11,7 @@ import {
   infobipSMSConfig,
   burstSmsConfig,
   clickatellConfig,
+  fortySixElksConfig,
 } from '../credentials';
 import { SmsProviderIdEnum } from '../provider.enum';
 
@@ -106,5 +107,13 @@ export const smsProviders: IProviderConfig[] = [
     betaVersion: true,
     docReference: 'https://docs.clickatell.com/',
     logoFileName: { light: 'clickatell.png', dark: 'clickatell.png' },
+  },
+  {
+    id: SmsProviderIdEnum.FortySixElks,
+    displayName: '46elks',
+    channel: ChannelTypeEnum.SMS,
+    credentials: fortySixElksConfig,
+    docReference: 'https://docs.clickatell.com/',
+    logoFileName: { light: '', dark: '' },
   },
 ];

--- a/libs/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/libs/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -521,3 +521,19 @@ export const infobipEmailConfig: IConfigCredentials[] = [
   },
   ...mailConfigBase,
 ];
+
+export const fortySixElksConfig: IConfigCredentials[] = [
+  {
+    key: CredentialsKeyEnum.User,
+    displayName: 'Username',
+    type: 'string',
+    required: true,
+  },
+  {
+    key: CredentialsKeyEnum.Password,
+    displayName: 'Password',
+    type: 'string',
+    required: true,
+  },
+  ...mailConfigBase,
+];

--- a/libs/shared/src/consts/providers/provider.enum.ts
+++ b/libs/shared/src/consts/providers/provider.enum.ts
@@ -57,6 +57,7 @@ export enum SmsProviderIdEnum {
   Infobip = 'infobip-sms',
   BurstSms = 'burst-sms',
   Clickatell = 'clickatell',
+  FortySixElks = '46elks',
 }
 
 export enum ChatProviderIdEnum {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2290,6 +2290,37 @@ importers:
       typedoc: 0.23.24_typescript@4.9.5
       typescript: 4.9.5
 
+  providers/forty-six-elks:
+    specifiers:
+      '@istanbuljs/nyc-config-typescript': ~1.0.1
+      '@novu/stateless': ^0.12.0
+      '@types/jest': ~27.5.2
+      axios: ^1.3.4
+      cspell: ~6.19.2
+      cz-conventional-changelog: ~3.3.0
+      jest: ~27.5.1
+      nyc: ~15.1.0
+      prettier: ~2.6.2
+      rimraf: ~3.0.2
+      ts-jest: ~27.1.5
+      ts-node: ~10.9.1
+      typescript: 4.9.5
+    dependencies:
+      '@novu/stateless': link:../../packages/stateless
+      axios: 1.3.4
+    devDependencies:
+      '@istanbuljs/nyc-config-typescript': 1.0.2_nyc@15.1.0
+      '@types/jest': 27.5.2
+      cspell: 6.19.2
+      cz-conventional-changelog: 3.3.0
+      jest: 27.5.1_ts-node@10.9.1
+      nyc: 15.1.0
+      prettier: 2.6.2
+      rimraf: 3.0.2
+      ts-jest: 27.1.5_j22lzoizerh26yhx3rtoqxu75q
+      ts-node: 10.9.1_263kxb4upkllfszsccwxso4xq4
+      typescript: 4.9.5
+
   providers/gupshup:
     specifiers:
       '@babel/preset-env': ^7.13.15
@@ -14513,15 +14544,15 @@ packages:
       '@commitlint/execute-rule': 17.4.0
       '@commitlint/resolve-extends': 17.4.4
       '@commitlint/types': 17.4.4
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       chalk: 4.1.2
       cosmiconfig: 8.0.0
-      cosmiconfig-typescript-loader: 4.3.0_a6hwc377sxr6di2ubbrssoxwmm
+      cosmiconfig-typescript-loader: 4.3.0_6xrdi26nkl7bvxgkef2umb6qhy
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1_shievopl57bw2yyflx5da526ye
+      ts-node: 10.9.1_263kxb4upkllfszsccwxso4xq4
       typescript: 4.9.5
     transitivePeerDependencies:
       - '@swc/core'
@@ -18175,7 +18206,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -18251,7 +18282,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -18330,7 +18361,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       jest-mock: 27.5.1
 
   /@jest/environment/29.3.1:
@@ -18365,7 +18396,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -18453,7 +18484,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -18678,7 +18709,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       '@types/yargs': 16.0.4
       chalk: 4.1.2
 
@@ -28831,7 +28862,7 @@ packages:
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
 
   /@types/handlebars/4.1.0:
     resolution: {integrity: sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==}
@@ -29082,7 +29113,6 @@ packages:
 
   /@types/node/16.11.7:
     resolution: {integrity: sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==}
-    dev: true
 
   /@types/node/16.18.3:
     resolution: {integrity: sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==}
@@ -32142,6 +32172,15 @@ packages:
     transitivePeerDependencies:
       - debug
 
+  /axios/1.3.4:
+    resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   /axobject-query/2.2.0:
     resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
 
@@ -34999,7 +35038,7 @@ packages:
       - '@swc/wasm'
     dev: true
 
-  /cosmiconfig-typescript-loader/4.3.0_a6hwc377sxr6di2ubbrssoxwmm:
+  /cosmiconfig-typescript-loader/4.3.0_6xrdi26nkl7bvxgkef2umb6qhy:
     resolution: {integrity: sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -35008,9 +35047,9 @@ packages:
       ts-node: '>=10'
       typescript: '>=3'
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       cosmiconfig: 8.0.0
-      ts-node: 10.9.1_shievopl57bw2yyflx5da526ye
+      ts-node: 10.9.1_263kxb4upkllfszsccwxso4xq4
       typescript: 4.9.5
     dev: true
 
@@ -36703,7 +36742,7 @@ packages:
     dev: true
 
   /detect-indent/5.0.0:
-    resolution: {integrity: sha1-OHHMCmoALow+Wzz38zYmRnXwa50=}
+    resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
     dev: true
 
@@ -38036,7 +38075,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.33.0
-      eslint-plugin-import: 2.26.0_ufewo3pl5nnmz6lltvjrdi2hii
+      eslint-plugin-import: 2.26.0_le6bq4wixy3va5oryeliptrdgy
       object.assign: 4.1.4
       object.entries: 1.1.6
       semver: 6.3.0
@@ -38054,7 +38093,7 @@ packages:
       '@typescript-eslint/parser': 5.50.0_4vsywjlpuriuw3tl5oq6zy5a64
       eslint: 8.33.0
       eslint-config-airbnb-base: 15.0.0_ga4sep7loct7ajt7pxcme7xdqu
-      eslint-plugin-import: 2.26.0_ufewo3pl5nnmz6lltvjrdi2hii
+      eslint-plugin-import: 2.26.0_le6bq4wixy3va5oryeliptrdgy
     dev: true
 
   /eslint-config-prettier/8.5.0_eslint@8.30.0:
@@ -40316,7 +40355,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
 
@@ -41186,9 +41225,6 @@ packages:
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
-  /graceful-fs/4.2.9:
-    resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
-
   /gradient-string/1.2.0:
     resolution: {integrity: sha512-Lxog7IDMMWNjwo4O0KbdBvSewk4vW6kQe5XaLuuPCyCE65AGQ1P8YqKJa5dq8TYf/Ge31F+KjWzPR5mAJvjlAg==}
     engines: {node: '>=4'}
@@ -41322,7 +41358,7 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
     dependencies:
-      minimist: 1.2.6
+      minimist: 1.2.7
       neo-async: 2.6.2
       source-map: 0.6.1
       wordwrap: 1.0.0
@@ -43344,7 +43380,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -43779,7 +43815,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -43819,7 +43855,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -43880,7 +43916,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
@@ -43920,7 +43956,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -44012,7 +44048,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
 
   /jest-mock/29.3.1:
     resolution: {integrity: sha512-H8/qFDtDVMFvFP4X8NuOT3XRDzOUTz+FeACjufHzsOIBAxivLqkB1PoLCaJx9iPPQ8dZThHPp/G3WRWyMgA3JA==}
@@ -44150,7 +44186,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.10
@@ -44271,7 +44307,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       graceful-fs: 4.2.10
 
   /jest-snapshot/27.5.1:
@@ -44355,7 +44391,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       chalk: 4.1.2
       graceful-fs: 4.2.10
       is-ci: 3.0.1
@@ -44367,7 +44403,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       chalk: 4.1.2
       ci-info: 3.3.0
       graceful-fs: 4.2.10
@@ -44428,7 +44464,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -44460,7 +44496,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 14.18.12
+      '@types/node': 16.11.7
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -44780,12 +44816,6 @@ packages:
     resolution: {integrity: sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=}
     dependencies:
       string-convert: 0.2.1
-
-  /json5/1.0.1:
-    resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
-    hasBin: true
-    dependencies:
-      minimist: 1.2.7
 
   /json5/1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -46836,6 +46866,7 @@ packages:
 
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+    dev: true
 
   /minimist/1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
@@ -48397,7 +48428,7 @@ packages:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.36
       '@zkochan/js-yaml': 0.0.6
-      axios: 1.3.3
+      axios: 1.3.4
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
@@ -57055,7 +57086,7 @@ packages:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
       '@types/json5': 0.0.29
-      json5: 1.0.1
+      json5: 1.0.2
       minimist: 1.2.7
       strip-bom: 3.0.0
 

--- a/providers/forty-six-elks/.czrc
+++ b/providers/forty-six-elks/.czrc
@@ -1,0 +1,3 @@
+{
+  "path": "cz-conventional-changelog"
+}

--- a/providers/forty-six-elks/.eslintrc.json
+++ b/providers/forty-six-elks/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.eslintrc.js"
+}

--- a/providers/forty-six-elks/.gitignore
+++ b/providers/forty-six-elks/.gitignore
@@ -1,0 +1,9 @@
+.idea/*
+.nyc_output
+build
+node_modules
+test
+src/**.js
+coverage
+*.log
+package-lock.json

--- a/providers/forty-six-elks/README.md
+++ b/providers/forty-six-elks/README.md
@@ -1,0 +1,9 @@
+# Novu FortySixElks Provider
+
+A FortySixElks sms provider library for [@novu/node](https://github.com/novuhq/novu)
+
+## Usage
+
+```javascript
+    FILL IN THE INITIALIZATION USAGE
+```

--- a/providers/forty-six-elks/jest.config.js
+++ b/providers/forty-six-elks/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/providers/forty-six-elks/package.json
+++ b/providers/forty-six-elks/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@novu/forty-six-elks",
+  "version": "^0.12.0",
+  "description": "A 46elks wrapper for novu",
+  "main": "build/main/index.js",
+  "typings": "build/main/index.d.ts",
+  "module": "build/module/index.js",
+  "private": false,
+  "repository": "https://github.com/novuhq/novu",
+  "license": "MIT",
+  "keywords": [],
+  "scripts": {
+    "prebuild": "rimraf build",
+    "build": "run-p build:*",
+    "build:main": "tsc -p tsconfig.json",
+    "build:module": "tsc -p tsconfig.module.json",
+    "fix": "run-s fix:*",
+    "fix:prettier": "prettier \"src/**/*.ts\" --write",
+    "fix:lint": "eslint src --ext .ts --fix",
+    "test": "run-s build test:*",
+    "test:lint": "eslint src --ext .ts",
+    "test:unit": "jest src",
+    "watch:build": "tsc -p tsconfig.json -w",
+    "watch:test": "jest src --watch",
+    "reset-hard": "git clean -dfx && git reset --hard && yarn",
+    "prepare-release": "run-s reset-hard test"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=13.0.0 <17.0.0",
+    "pnpm": "^7.26.0"
+  },
+  "dependencies": {
+    "@novu/stateless": "^0.12.0",
+    "axios": "^1.3.4"
+  },
+  "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "~1.0.1",
+    "@types/jest": "~27.5.2",
+    "cspell": "~6.19.2",
+    "cz-conventional-changelog": "~3.3.0",
+    "jest": "~27.5.1",
+    "nyc": "~15.1.0",
+    "prettier": "~2.6.2",
+    "rimraf": "~3.0.2",
+    "ts-jest": "~27.1.5",
+    "ts-node": "~10.9.1",
+    "typescript": "4.9.5"
+  },
+  "files": [
+    "build/main",
+    "build/module",
+    "!**/*.spec.*",
+    "!**/*.json",
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md"
+  ],
+  "ava": {
+    "failFast": true,
+    "timeout": "60s",
+    "typescript": {
+      "rewritePaths": {
+        "src/": "build/main/"
+      }
+    },
+    "files": [
+      "!build/module/**"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true
+  },
+  "nyc": {
+    "extends": "@istanbuljs/nyc-config-typescript",
+    "exclude": [
+      "**/*.spec.js"
+    ]
+  }
+}

--- a/providers/forty-six-elks/src/index.ts
+++ b/providers/forty-six-elks/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/forty-six-elks.provider';

--- a/providers/forty-six-elks/src/lib/forty-six-elks.provider.spec.ts
+++ b/providers/forty-six-elks/src/lib/forty-six-elks.provider.spec.ts
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import { FortySixElksSmsProvider } from './forty-six-elks.provider';
+
+test('should trigger 46elks api correctly', async () => {
+  const spy = jest.spyOn(axios, 'post').mockImplementation(async () => {
+    return {
+      data: {
+        id: 'test_id',
+        created: new Date().toISOString(),
+      },
+    };
+  });
+
+  const to = '+467777777777';
+  const from = 'Company';
+  const content = 'Test';
+
+  const provider = new FortySixElksSmsProvider({
+    user: 'test_account',
+    password: '123456',
+    from,
+  });
+
+  const response = await provider.sendMessage({
+    to,
+    from,
+    content,
+  });
+
+  expect(response?.id).toEqual('test_id');
+  expect(spy).toHaveBeenCalledWith(
+    'https://api.46elks.com/a1/sms',
+    `from=${from}&to=${to.replace('+', '%2B')}&message=${content}`,
+    { headers: { Authorization: 'Basic dGVzdF9hY2NvdW50OjEyMzQ1Ng==' } }
+  );
+});

--- a/providers/forty-six-elks/src/lib/forty-six-elks.provider.ts
+++ b/providers/forty-six-elks/src/lib/forty-six-elks.provider.ts
@@ -1,0 +1,67 @@
+import axios from 'axios';
+import {
+  ChannelTypeEnum,
+  ISendMessageSuccessResponse,
+  ISmsOptions,
+  ISmsProvider,
+} from '@novu/stateless';
+
+interface IFortySixElksSuccessObject {
+  status: string;
+  direction: string;
+  from: string;
+  created: string;
+  parts: number;
+  to: string;
+  cost: number;
+  message: string;
+  id: string;
+}
+
+interface IFortySixElksRequestResponse {
+  data: IFortySixElksSuccessObject;
+}
+
+export class FortySixElksSmsProvider implements ISmsProvider {
+  id = '46elks';
+  channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
+
+  constructor(
+    private config: {
+      user: string;
+      password: string;
+      from: string;
+    }
+  ) {}
+
+  async sendMessage(
+    options: ISmsOptions
+  ): Promise<ISendMessageSuccessResponse> {
+    const authKey = Buffer.from(
+      this.config.user + ':' + this.config.password
+    ).toString('base64');
+
+    const data = new URLSearchParams({
+      from: this.config.from,
+      to: options.to,
+      message: options.content,
+    }).toString();
+
+    const config = {
+      headers: {
+        Authorization: 'Basic ' + authKey,
+      },
+    };
+
+    const res: IFortySixElksRequestResponse = await axios.post(
+      'https://api.46elks.com/a1/sms',
+      data,
+      config
+    );
+
+    return {
+      id: res.data.id,
+      date: res.data.created,
+    };
+  }
+}

--- a/providers/forty-six-elks/tsconfig.json
+++ b/providers/forty-six-elks/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build/main",
+    "rootDir": "src",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules/**"]
+}

--- a/providers/forty-six-elks/tsconfig.module.json
+++ b/providers/forty-six-elks/tsconfig.module.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "target": "esnext",
+    "outDir": "build/module",
+    "module": "esnext"
+  },
+  "exclude": ["node_modules/**"]
+}


### PR DESCRIPTION
Adding support for the Sweden-based SMS API provider [46elks](https://46elks.se/). Used the [official Novu guide](https://docs.novu.co/community/create-provider/) in the process.

Since the docs say that logos are optional, I've left them empty for now. Would have added the relevant images, but 46Elks only have a [press kit with their blue logo on their website](https://46elks.se/press). Since Novu requests both dark and light mode logos, we'd have to flip some colors to create a light version (totally doable in 2 minutes in GIMP, but need to decide on which colors to use first).